### PR TITLE
Only compile material locking when building with a renderer

### DIFF
--- a/Unreal/MeshCommon.cpp
+++ b/Unreal/MeshCommon.cpp
@@ -170,6 +170,7 @@ void BuildTangentsCommon(CMeshVertex *Verts, int VertexSize, const CIndexBuffer 
 	unguard;
 }
 
+#if RENDERING
 void CBaseMeshLod::LockMaterials()
 {
 	for (int i = 0; i < Sections.Num(); i++)
@@ -187,3 +188,4 @@ void CBaseMeshLod::UnlockMaterials()
 		if (Material) Material->Unlock();
 	}
 }
+#endif

--- a/Unreal/MeshCommon.h
+++ b/Unreal/MeshCommon.h
@@ -186,8 +186,10 @@ struct CBaseMeshLod
 			ExtraUV[i] = (CMeshUVFloat*)appMalloc(sizeof(CMeshUVFloat) * NumVerts);
 	}
 
+#if RENDERING
 	void LockMaterials();
 	void UnlockMaterials();
+#endif
 };
 
 void BuildNormalsCommon(CMeshVertex *Verts, int VertexSize, int NumVerts, const CIndexBuffer &Indices);

--- a/Unreal/SkeletalMesh.h
+++ b/Unreal/SkeletalMesh.h
@@ -131,6 +131,7 @@ public:
 
 	void FinalizeMesh();
 
+#if RENDERING
 	void LockMaterials()
 	{
 		for (int i = 0; i < Lods.Num(); i++)
@@ -142,6 +143,7 @@ public:
 		for (int i = 0; i < Lods.Num(); i++)
 			Lods[i].UnlockMaterials();
 	}
+#endif
 
 	void SortBones();
 	int FindBone(const char *Name) const;

--- a/Unreal/StaticMesh.h
+++ b/Unreal/StaticMesh.h
@@ -76,6 +76,7 @@ public:
 			Lods[i].BuildNormals();
 	}
 
+#if RENDERING
 	void LockMaterials()
 	{
 		for (int i = 0; i < Lods.Num(); i++)
@@ -87,6 +88,7 @@ public:
 		for (int i = 0; i < Lods.Num(); i++)
 			Lods[i].UnlockMaterials();
 	}
+#endif
 
 #if DECLARE_VIEWER_PROPS
 	DECLARE_STRUCT(CStaticMesh)


### PR DESCRIPTION
I'm using your code as a dependency in a third-party, headless app (i.e. no renderer). This change allows using mesh source code unmodified by headless applications. It simply follows from the fact that most of the `UUnrealMaterial` class is also #ifdefed away with `#if RENDERING`.