### PR TITLE
Ignore mobile texture formats in UnTexture3.cpp when not building mobile

### DIFF
--- a/Unreal/UnTexture3.cpp
+++ b/Unreal/UnTexture3.cpp
@@ -846,6 +846,7 @@ bool UTexture2D::GetTextureData(CTextureData &TexData) const
 		intFormat = TPF_BC5;
 #endif // MASSEFF
 #if UNREAL4
+#if SUPPORT_ANDROID || SUPPORT_IOS
 	else if (Format == PF_PVRTC2)
 		intFormat = TPF_PVRTC2;
 	else if (Format == PF_PVRTC4)
@@ -854,6 +855,7 @@ bool UTexture2D::GetTextureData(CTextureData &TexData) const
 		intFormat = TPF_ETC1;
 //!!	else if (Format == PF_ETC2_RGB)		// GL_COMPRESSED_RGB8_ETC2
 //!!	else if (Format == PF_ETC2_RGBA)	// GL_COMPRESSED_RGBA8_ETC2_EAC
+#endif // SUPPORT_ANDROID || SUPPORT_IOS
 #endif // UNREAL4
 	else
 	{


### PR DESCRIPTION
Again, I'm using UModel's source code as a dependency for another app. When `SUPPORT_ANDROID` and/or `SUPPORT_IOS` is not defined, this file will fail to compile due to the `PF_*` enums being undeclared symbols.

The change is quite noninvasive, I've simply #ifdefed these away with those macros.