### PR TITLE
Cast zeroes to hkInt16 explicitly to ensure same type

### DIFF
--- a/Unreal/UnMeshBioshock.cpp
+++ b/Unreal/UnMeshBioshock.cpp
@@ -637,7 +637,7 @@ void USkeletalMesh::PostLoadBioshockMesh()
 		{
 			FMeshBone &B = RefSkeleton[i];
 			B.Name.Str    = Skel->m_bones[i]->m_name;				//?? hack: FName assignment
-			B.ParentIndex = max(Skel->m_parentIndices[i], 0);
+			B.ParentIndex = max(Skel->m_parentIndices[i], (hkInt16)0);
 			const hkQsTransform &t = Skel->m_referencePose[i];
 			B.BonePos.Orientation = (FQuat&)   t.m_rotation;
 			B.BonePos.Position    = (FVector&) t.m_translation;
@@ -657,7 +657,7 @@ void USkeletalMesh::PostLoadBioshockMesh()
 		{
 			FMeshBone &B = RefSkeleton[i];
 			B.Name.Str    = Skel->m_bones[i]->m_name;				//?? hack: FName assignment
-			B.ParentIndex = max(Skel->m_parentIndices[i], 0);
+			B.ParentIndex = max(Skel->m_parentIndices[i], (hkInt16)0);
 			const hkQsTransform &t = Skel->m_referencePose[i];
 			B.BonePos.Orientation = (FQuat&)   t.m_rotation;
 			B.BonePos.Position    = (FVector&) t.m_translation;


### PR DESCRIPTION
Again, compiling UModel as a dependency for another app.

Having `max` #defined to `std::max`, the compiler complains about the argument types not being equal. This non-invasive change simply makes an explicit cast of the zero to ensure that the types are the same.