### PR TITLE
Surround in-place operator new() for TArray elements with an #ifndef

### DIFF
--- a/Unreal/UnCore.h
+++ b/Unreal/UnCore.h
@@ -1720,6 +1720,7 @@ protected:
 	T		StaticData[N];
 };
 
+#ifndef NO_OPERATOR_NEW_TARRAY_DEFINITION
 template<typename T>
 FORCEINLINE void* operator new(size_t size, TArray<T> &Array)
 {
@@ -1729,6 +1730,7 @@ FORCEINLINE void* operator new(size_t size, TArray<T> &Array)
 	return Array.GetData() + index;
 	unguard;
 }
+#endif
 
 
 // Skip array of items of fixed size


### PR DESCRIPTION
Again, compiling UModel as a dependency for another app. This is a little bit controversial, and I will understand if you do not want to merge it.

I'm putting all of UModel's code in a separate namespace to avoid symbol clashing with my app's code (yes, it is possible to have them). However, this puts the overloaded `operator new()` for in-place `TArray` element construction into the namespace, causing MSVC compiler error C2323 (see [here](https://msdn.microsoft.com/en-us/library/mt723604.aspx), section "Overloaded operator new and operator delete").

This change is as non-invasive as I could make it, and it allows opting-out of defining the operator by simply #defining `NO_OPERATOR_NEW_TARRAY_DEFINITION`. Default behaviour remains unchanged.

I'm fine with changing the name of the macro as well, if you don't find this one descriptive enough.