### PR TITLE
Fix missing or incorrect return statements in UnCore.h

### DIFF
--- a/Unreal/UnCore.h
+++ b/Unreal/UnCore.h
@@ -1658,7 +1658,7 @@ protected:
 	{}
 	TArray& operator=(const TArray &Other)
 	{
-		return this;
+		return *this;
 	}
 	// Helper function to reduce TLazyArray etc operator<<'s code size.
 	// Used as C-style wrapper around TArray<>::operator<<().
@@ -1910,6 +1910,7 @@ public:
 	{
 		int index = Data.AddUninitialized();
 		Data[index] = ch;
+		return *this;
 	}
 
 	FORCEINLINE void RemoveAt(int index, int count = 1)


### PR DESCRIPTION
Methods involved are `TArray::operator=()` (which is meant to disable array copying), where the return type was incorrect, and `FString::AppendChar()`, which did not return a value at all. Wonder why this never came up before.