### PR TITLE
Fix _findnexti64() crashing on Win64 compiled by MSVC

### DIFF
--- a/Unreal/GameFileSystem.cpp
+++ b/Unreal/GameFileSystem.cpp
@@ -380,7 +380,7 @@ static bool ScanGameDirectory(const char *dir, bool recurse)
 #if _WIN32
 	appSprintf(ARRAY_ARG(Path), "%s/*.*", dir);
 	_finddatai64_t found;
-	long hFind = _findfirsti64(Path, &found);
+	intptr_t hFind = _findfirsti64(Path, &found);
 	if (hFind == -1) return true;
 	do
 	{


### PR DESCRIPTION
I was getting crashes in the `_findnexti64()` call trying to access pointers in the style of 0x00000000XXXXXXXX (i.e. upper half of the word was zeroed). This made me suspicious that there's some pointer type truncation going on. Upon investigation, I've found that the return value of `_findfirsti64()` was being written to a `long` variable (which is always a 32-bit integer in MSVC), whereas the function returns an `intptr_t` (i.e. type equivalent in size to platform-specific pointer, and 64 bits in this case).