### PR TITLE
Fix NVTT builds in MSVC >= 14.0

### DIFF
--- a/libs/nvtt/nvcore/DefsVcWin32.h
+++ b/libs/nvtt/nvcore/DefsVcWin32.h
@@ -18,7 +18,9 @@
 #define NV_CONST
 
 // Set standard function names.
-#define snprintf _snprintf
+#if _MSC_VER < 1900
+#	define snprintf _snprintf
+#endif
 #if _MSC_VER < 1500
 #	define vsnprintf _vsnprintf
 #endif


### PR DESCRIPTION
This fixes a compile error when building with MSVS 2015:
`fatal error C1189: #error: Macro definition of snprintf conflicts with Standard Library function declaration`
And the reason is that they've finally added `snprintf()` in MSVS 2015's SDK. Compare this:
https://msdn.microsoft.com/en-us/library/2ts7cx93(v=vs.140).aspx
to this:
https://msdn.microsoft.com/en-us/library/2ts7cx93(v=vs.120).aspx

The reason I haven't stumbled onto it before is that now I'm also building using your build system. Before that, I was specifically excluding `nvcore.h` from my builds to avoid symbol conflicts.