### PR TITLE
Trivial fixes to the TypeInfo tool

### DIFF
--- a/Tools/TypeInfo/Main.cpp
+++ b/Tools/TypeInfo/Main.cpp
@@ -229,7 +229,7 @@ void DumpClass(const UClass *Class)
 
 bool DumpTextBuffer(const UTextBuffer *Text)
 {
-	if (!Text->Text.Num()) return false;		// empty
+	if (!Text->Text.Len()) return false;		// empty
 
 	// get class name (UTextBuffer's outer UPackage)
 	const FObjectExport &Exp = Text->Package->GetExport(Text->PackageIndex);
@@ -238,7 +238,7 @@ bool DumpTextBuffer(const UTextBuffer *Text)
 	char Filename[256];
 	appSprintf(ARRAY_ARG(Filename), "%s/%s.uc", Text->Package->Name, ClassName);
 	FFileWriter Ar(Filename);
-	Ar.Serialize((void*)*Text->Text, Text->Text.Num());
+	Ar.Serialize((void*)*Text->Text, Text->Text.Len());
 
 	return true;
 }

--- a/Tools/TypeInfo/typeinfo.project
+++ b/Tools/TypeInfo/typeinfo.project
@@ -8,6 +8,7 @@ sources(MAIN) = {
 	Main.cpp
 	$R/Unreal/UnCore.cpp
 	$R/Unreal/UnCoreCompression.cpp
+	$R/Unreal/UnCoreDecrypt.cpp
 	$R/Unreal/UnCoreSerialize.cpp
 	$R/Unreal/UnObject.cpp
 	$R/Unreal/UnPackage.cpp


### PR DESCRIPTION
I've realized that my attempts to write a Python UScript parser are misguided, since the same data may be recovered from compiled script class data, and was pleasantly surprised that you have already created the tool and it is almost complete. :) It didn't build, though, so here are some trivial fixes:

`FString` has a `Len()` method, not `Num()`, and `UnCoreDecrypt.cpp` is required for the decryption routines.