### PR TITLE
VTXNORMS chunk for ActorX (vertex normals)

### DIFF
--- a/Exporters/ExportPsk.cpp
+++ b/Exporters/ExportPsk.cpp
@@ -80,7 +80,7 @@ static void ExportCommonMeshData
 	guard(ExportCommonMeshData);
 
 	// using 'static' here to avoid zero-filling unused fields
-	static VChunkHeader MainHdr, PtsHdr, WedgHdr, FacesHdr, MatrHdr;
+	static VChunkHeader MainHdr, PtsHdr, WedgHdr, FacesHdr, MatrHdr, NormHdr;
 	int i;
 
 #define SECT(n)		(Sections + n)
@@ -244,6 +244,22 @@ static void ExportCommonMeshData
 		else
 			appSprintf(ARRAY_ARG(M.MaterialName), "material_%d", i);
 		Ar << M;
+	}
+	unguard;
+
+	guard(Normals);
+	NormHdr.DataCount = Share.Normals.Num();
+	NormHdr.DataSize  = sizeof(CVec3);
+	SAVE_CHUNK(NormHdr, "VTXNORMS");
+	for (i = 0; i < Share.Normals.Num(); i++)
+	{
+		CVec3 Normal;
+		Unpack(Normal, Share.Normals[i]);
+		Normal.Normalize();
+#if MIRROR_MESH
+		Normal.Y = -Normal.Y;
+#endif
+		Ar << Normal.X << Normal.Y << Normal.Z;
 	}
 	unguard;
 

--- a/Exporters/Psk.h
+++ b/Exporters/Psk.h
@@ -2,7 +2,7 @@
 #define __PSK_H__
 
 
-#define PSK_VERSION		20100422
+#define PSK_VERSION		20210917 // VTXNORMS chunk
 #define PSA_VERSION		20100422
 
 /******************************************************************************


### PR DESCRIPTION
Blender plugins that support this chunk:

- [blender3d_import_psk_psa by Befzz](https://github.com/Befzz/blender3d_import_psk_psa/tree/latest/addons) (https://github.com/Befzz/blender3d_import_psk_psa/pull/69)
- [io_scene_psk_psa by DarklightGames](https://github.com/DarklightGames/io_scene_psk_psa) (https://github.com/DarklightGames/io_scene_psk_psa/pull/17)