### PR TITLE
Use double-bracket test for Darwin OSTYPE matching

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -115,7 +115,7 @@ function DetectBuildPlatform()
 		else
 			PLATFORM="linux32"
 		fi
-	elif [ "$OSTYPE" == "darwin"* ]; then
+	elif [[ "$OSTYPE" == "darwin"* ]]; then
 		PLATFORM=osx
 	else
 		[ "$PLATFORM" ] || PLATFORM="vc-win32"


### PR DESCRIPTION
Pattern matching "darwin"* requires double-bracket test, otherwise it's file globbing.

---

From https://tldp.org/LDP/abs/html/comparison-ops.html#SCOMPARISON2 :
![image](https://github.com/gildor2/UEViewer/assets/23431373/7038cb12-e27c-4c51-9cf1-8283f1bc9f40)

When trying to build on a Darwin machine, the `$OSTYPE` check would always fail and fall back to the `PLATFORM="vc-win32"` branch. This should fix the check and get the build to start.