### PR TITLE
Don't use c++2a standard on Darwin

### DIFF
--- a/common.project
+++ b/common.project
@@ -63,8 +63,6 @@ CPP_STD = c++14				# allow modern C++ features
 	!endif
 	!if "$PLATFORM" ne "osx"
 		STDLIBS += GL
-	!else
-		CPP_STD = c++2a									# https://github.com/gildor2/UEViewer/issues/183#issuecomment-846745134
 	!endif
 
 	LIBC      = shared


### PR DESCRIPTION
Because this special casing causes the build to fail in my build environment:

```
Export3D.cpp
+ g++ -c -msse2 -fno-strict-aliasing -fno-stack-protector -Wunused-value -Os -std=c++2a -Wno-invalid-offsetof -I . -I ./Core -I ./Unreal -I ./libs/include -I ./libs -I ./libs/nvtt -I /usr/include/libpng -I ./libs/PowerVR -I ./libs/detex -I ./libs/rijndael -I UmodelTool -I UI -o ./obj/umodel-osx/Export3D.o Exporters/Export3D.cpp
In file included from Exporters/Export3D.cpp:1:
./Core/Core.h:387:19: error: redefinition of 'void* operator new(size_t, void*)'
  387 | FORCEINLINE void* operator new(size_t /*size*/, void* ptr)
      |                   ^~~~~~~~
In file included from /nix/store/05mkqaciqsglmxl43vmz96np2izykfli-gcc-12.3.0/include/c++/12.3.0/bits/stl_iterator.h:82,
                 from /nix/store/05mkqaciqsglmxl43vmz96np2izykfli-gcc-12.3.0/include/c++/12.3.0/bits/stl_algobase.h:67,
                 from /nix/store/05mkqaciqsglmxl43vmz96np2izykfli-gcc-12.3.0/include/c++/12.3.0/bits/specfun.h:45,
                 from /nix/store/05mkqaciqsglmxl43vmz96np2izykfli-gcc-12.3.0/include/c++/12.3.0/cmath:1935,
                 from /nix/store/05mkqaciqsglmxl43vmz96np2izykfli-gcc-12.3.0/include/c++/12.3.0/math.h:36,
                 from ./Core/Core.h:14:
/nix/store/05mkqaciqsglmxl43vmz96np2izykfli-gcc-12.3.0/include/c++/12.3.0/new:174:33: note: 'void* operator new(std::size_t, void*)' previously defined here
  174 | _GLIBCXX_NODISCARD inline void* operator new(std::size_t, void* __p) _GLIBCXX_USE_NOEXCEPT
      |                                 ^~~~~~~~
```