### PR TITLE
Support for loading packages from the BioShock Infinite Nov. 2012 prototype

### DIFF
--- a/Unreal/GameDatabase.cpp
+++ b/Unreal/GameDatabase.cpp
@@ -773,7 +773,7 @@ void FArchive::DetectGame()
 	if (ArVer == 721 && ArLicenseeVer == 148)	SET(GAME_Thief4);
 #endif
 #if BIOSHOCK3
-	if (ArVer == 727 && ArLicenseeVer == 75)	SET(GAME_Bioshock3);
+	if (ArVer == 727 && (ArLicenseeVer == 75 || ArLicenseeVer == 69))	SET(GAME_Bioshock3);
 #endif
 #if BULLETSTORM
 	if (ArVer == 742 && ArLicenseeVer == 29)	SET(GAME_Bulletstorm);

--- a/Unreal/UnrealPackage/UnPackage3.cpp
+++ b/Unreal/UnrealPackage/UnPackage3.cpp
@@ -206,7 +206,7 @@ void FPackageFileSummary::Serialize3(FArchive &Ar)
 		Ar << DependsOffset;
 
 #if BIOSHOCK3
-	if (Ar.Game == GAME_Bioshock3) goto read_unk38;
+	if (Ar.Game == GAME_Bioshock3 && Ar.ArLicenseeVer > 69) goto read_unk38;
 #endif
 
 #if DUNDEF


### PR DESCRIPTION
An older version of BioShock Infinite recently came to light and initially umodel didn't appear to be able to load the packages. It turned out to only require a small amendment to resolve.