### PR TITLE
Potential fix for NULL Pointer Dereference

### DIFF
--- a/UI/BaseDialog.cpp
+++ b/UI/BaseDialog.cpp
@@ -306,7 +306,7 @@ void UIElement::MeasureTextVSize(const char* text, int* width, int* height, HWND
 	assert(wnd);
 
 	// get control's width
-	int w = *width;
+	int w = width ? *width : -1;
 	if (w < 0)
 	{
 		//!! see AllocateUISpace() for details, should separate common code in some way


### PR DESCRIPTION
Not a major issue but this one popped up after enabling the security code scan on the repo.

Potential fix for code scanning alert no. 1: Redundant null check due to previous dereference
This rule finds comparisons of a pointer to null that occur after a reference of that pointer. It's likely either the check is not required and can be removed, or it should be moved to before the dereference so that a null pointer dereference does not occur.

References
Null Dereference
https://owasp.org/www-community/vulnerabilities/Null_Dereference

Common Weakness Enumeration: CWE-476.
https://cwe.mitre.org/data/definitions/476.html